### PR TITLE
Allow to cdnify the urls from internal tags and attributes in the tags

### DIFF
--- a/tasks/cdnify.js
+++ b/tasks/cdnify.js
@@ -125,7 +125,10 @@ module.exports = function (grunt) {
             });
 
           // Write it to disk
-          grunt.file.write(destFile, soup.toString());
+          // grunt.file.write(destFile, soup.toString());
+          // work with all url even inside of tags as attibute
+          var newOutPut = rewriteCSSURLs(soup.toString(), rewriteURL);
+          grunt.file.write(destFile, newOutPut);
           grunt.log.ok("Wrote HTML file: \"" + destFile + "\"");
         }
       }


### PR DESCRIPTION
cdnify URLs that can be located in the tags at any location (including tag attributes and internal values on that attributes)

i.e.
```html
<div style="background-image:url('/images/homePage/fe18b3f3f137.1.png')"></div>
```