### PR TITLE
Fixed nodeunit version and some cases where the url joining fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   ],
   "devDependencies": {
-    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.11",

--- a/test/expected/sample.css
+++ b/test/expected/sample.css
@@ -1,6 +1,8 @@
 body {
   background-image: url('//cdn.example.com/stuff/foo.jpg');
   background-image: url('//cdn.example.com/foo.jpg');
+  background-image: url('//cdn.example.com/foo/bar/test.jpg');
+  background-image: url('//cdn.example.com/foo/bar/test.jpg');
   background-image: url('//cdn.example.com/foo.jpg');
   background-image: url('//cdn.example.com/stuff/foo/bar.jpg');
 }

--- a/test/fixtures/sample.css
+++ b/test/fixtures/sample.css
@@ -1,6 +1,8 @@
 body {
   background-image: url('foo.jpg');
   background-image: url('/foo.jpg');
+  background-image: url('/foo/bar/test.jpg');
+  background-image: url('../../foo/bar/test.jpg');
   background-image: url('../foo.jpg');
   background-image: url('foo/bar.jpg');
 }


### PR DESCRIPTION
Updated grunt-contrib-nodeunit to the latest version and replaced the custom "joinBaseAndPath" function with the core url.resolve one in order to fix some cases where the joining didn't work. Ex: '../../foo/bar.jpg' was resolved to '../..//foo/bar.jpg'.