### PR TITLE
Replaced custom joinBaseAndPath function to use core `url.resolve` wh…

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "css-url-rewriter": "^0.1.0",
-    "path-posix": "^1.0.0",
     "soup": "^0.1.3"
   },
   "devDependencies": {

--- a/test/expected/sample.css
+++ b/test/expected/sample.css
@@ -1,6 +1,8 @@
 body {
   background-image: url('//cdn.example.com/stuff/foo.jpg');
   background-image: url('//cdn.example.com/foo.jpg');
+  background-image: url('//cdn.example.com/foo/bar/test.jpg');
+  background-image: url('//cdn.example.com/foo/bar/test.jpg');
   background-image: url('//cdn.example.com/foo.jpg');
   background-image: url('//cdn.example.com/stuff/foo/bar.jpg');
 }

--- a/test/fixtures/sample.css
+++ b/test/fixtures/sample.css
@@ -1,6 +1,8 @@
 body {
   background-image: url('foo.jpg');
   background-image: url('/foo.jpg');
+  background-image: url('/foo/bar/test.jpg');
+  background-image: url('../../foo/bar/test.jpg');
   background-image: url('../foo.jpg');
   background-image: url('foo/bar.jpg');
 }


### PR DESCRIPTION
This fixes some cases where relative paths are not replaced correctly (e.g. `../../foo/bar.jpg`).

This is #21 rebased and tweaked up.

Everything seems to work fine but CC'ing @callumlocke for a quick look.